### PR TITLE
Fixed dialog not showing in QueueUploader, login consistency

### DIFF
--- a/Libs/iSENSE_API/Source/API.m
+++ b/Libs/iSENSE_API/Source/API.m
@@ -21,9 +21,6 @@
 
 #define BOUNDARY @"*****"
 
-#define PREFS_EMAIL @"api_prefs_key_email"
-#define PREFS_PASSWORD @"api_prefs_key_password"
-
 static NSString *baseUrl, *authenticityToken;
 static RPerson *currentUser;
 static NSString *email, *password;
@@ -844,8 +841,8 @@ static NSString *email, *password;
 -(void)saveCurrentUserToPrefs {
 
     NSUserDefaults *prefs = [NSUserDefaults standardUserDefaults];
-    [prefs setObject:email forKey:PREFS_EMAIL];
-    [prefs setObject:password forKey:PREFS_PASSWORD];
+    [prefs setObject:email forKey:KEY_USERNAME];
+    [prefs setObject:password forKey:KEY_PASSWORD];
     [prefs synchronize];
 }
 
@@ -858,9 +855,9 @@ static NSString *email, *password;
 -(bool)loadCurrentUserFromPrefs {
 
     NSUserDefaults *prefs = [NSUserDefaults standardUserDefaults];
-    if ([prefs objectForKey:PREFS_EMAIL] && [prefs objectForKey:PREFS_PASSWORD])
-        if ([self createSessionWithEmail:[prefs objectForKey:PREFS_EMAIL]
-                             andPassword:[prefs objectForKey:PREFS_PASSWORD]])
+    if ([prefs objectForKey:KEY_USERNAME] && [prefs objectForKey:KEY_PASSWORD])
+        if ([self createSessionWithEmail:[prefs objectForKey:KEY_USERNAME]
+                             andPassword:[prefs objectForKey:KEY_PASSWORD]])
             return true;
 
     return false;

--- a/Libs/iSENSE_API/headers/API.h
+++ b/Libs/iSENSE_API/headers/API.h
@@ -14,6 +14,7 @@
 #import "RNews.h"
 #import "RProjectField.h"
 #import "Reachability.h"
+#import "ISKeys.h"
 #import <MobileCoreServices/UTType.h>
 #import <sys/time.h>
 

--- a/Libs/iSENSE_API/headers/QueueUploaderView.h
+++ b/Libs/iSENSE_API/headers/QueueUploaderView.h
@@ -24,8 +24,6 @@
 #import <AVFoundation/AVFoundation.h>
 #import <AVFoundation/AVCaptureDevice.h>
 
-#define KEY_ATTEMPTED_UPLOAD    @"key_attempted_upload"
-
 // Parent name constants: add a new one for each app
 #define PARENT_AUTOMATIC    @"Automatic"
 #define PARENT_MANUAL       @"Manual"


### PR DESCRIPTION
- removed individual API pref keys for saving login information and made library conformed to the keys defined in ISKeys.h.  As a result, logging in at the QueueUploaderView will now properly save credentials that will be picked up by the CredentialManager, as they should
- got the dispatch dialogs to actually show when logging in/uploading, and make API tasks work in the background thread
#7
