### PR TITLE
Splash/Tutorial/Preset reviews available in Motion and Writer menu

### DIFF
--- a/Apps/Motion/Motion/Base.lproj/Main.storyboard
+++ b/Apps/Motion/Motion/Base.lproj/Main.storyboard
@@ -194,6 +194,11 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="iS Motion" id="d6B-Tu-Otv">
+                        <barButtonItem key="leftBarButtonItem" title="Review" id="1g5-YL-olo">
+                            <connections>
+                                <action selector="menuBarBtnOnClick:" destination="vXZ-lx-hvc" id="NTR-KW-q73"/>
+                            </connections>
+                        </barButtonItem>
                         <barButtonItem key="rightBarButtonItem" title="Account" id="YgZ-s9-4Sq">
                             <connections>
                                 <action selector="credentialBarBtnOnClick:" destination="vXZ-lx-hvc" id="NMf-fA-kYZ"/>
@@ -202,6 +207,7 @@
                     </navigationItem>
                     <connections>
                         <outlet property="credentialBarBtn" destination="YgZ-s9-4Sq" id="Uyv-Ku-Itv"/>
+                        <outlet property="menuBarBtn" destination="1g5-YL-olo" id="ohh-rq-Ot4"/>
                         <outlet property="nameBtn" destination="0MA-CP-WU0" id="TLh-l3-ieQ"/>
                         <outlet property="projectBtn" destination="43J-wk-nCk" id="7Ac-Af-eev"/>
                         <outlet property="recordingLengthBtn" destination="sUa-1z-o5u" id="IWI-bE-3LV"/>

--- a/Apps/Motion/Motion/Constants.h
+++ b/Apps/Motion/Motion/Constants.h
@@ -26,6 +26,11 @@
 
 #define kVISUALIZE_DIALOG_TAG 700
 
+#define kMENU_DIALOG_TAG 800
+#define kBTN_SPLASH 1
+#define kBTN_TUTORIALS 2
+#define kBTN_PRESETS 3
+
 // Earth's gravity constant
 #define kGRAVITY 9.80665
 

--- a/Apps/Motion/Motion/ISMTutorialViewController.m
+++ b/Apps/Motion/Motion/ISMTutorialViewController.m
@@ -69,7 +69,8 @@
         UIStoryboard *presetStoryboard = [UIStoryboard storyboardWithName:@"Preset" bundle:nil];
         ISMPresets *presetController = [presetStoryboard instantiateViewControllerWithIdentifier:@"PresetStartController"];
         [presetController setDelegate:delegate];
-        [[[[[UIApplication sharedApplication] delegate] window] rootViewController] presentViewController:presetController animated:NO completion:nil];
+        [[[[[UIApplication sharedApplication] delegate] window]
+          rootViewController] presentViewController:presetController animated:NO completion:nil];
     }];
 }
 

--- a/Apps/Motion/Motion/ISMViewController.h
+++ b/Apps/Motion/Motion/ISMViewController.h
@@ -70,6 +70,10 @@
     // and value is the respective sample rate/recording length as a string
     NSDictionary *sampleRateStrings;
     NSDictionary *recLengthStrings;
+
+    // UIView to display the splash screen and a boolean to track if it is displaying
+    UIView *splashView;
+    bool isSplashDisplaying;
 }
 
 // Queue Saver Properties
@@ -77,6 +81,9 @@
 @property (nonatomic, strong) NSManagedObjectContext *managedObjectContext;
 
 // UI elements and click methods
+@property (weak, nonatomic) IBOutlet UIBarButtonItem *menuBarBtn;
+- (IBAction)menuBarBtnOnClick:(id)sender;
+
 @property (weak, nonatomic) IBOutlet UIBarButtonItem *credentialBarBtn;
 - (IBAction)credentialBarBtnOnClick:(id)sender;
 

--- a/Apps/Motion/Motion/ISMViewController.m
+++ b/Apps/Motion/Motion/ISMViewController.m
@@ -250,13 +250,23 @@
             switch (buttonIndex) {
                 case kBTN_SPLASH:
                 {
-                    // get the splash view from the LaunchScreen xib
-                    NSArray *bundle = [[NSBundle mainBundle] loadNibNamed:@"LaunchScreen" owner:self options:nil];
-                    for (id obj in bundle) {
-                        if ([obj isKindOfClass:[UIView class]]) {
-                            splashView = (UIView *) obj;
-                            break;
+                    if (!splashView) {
+                        // get the splash view from the LaunchScreen xib
+                        NSArray *bundle = [[NSBundle mainBundle] loadNibNamed:@"LaunchScreen" owner:self options:nil];
+                        for (id obj in bundle) {
+                            if ([obj isKindOfClass:[UIView class]]) {
+                                splashView = (UIView *) obj;
+                                break;
+                            }
                         }
+                    }
+
+                    if (!splashView) {
+                        [self.view makeWaffle:@"Error loading splash screen"
+                                     duration:WAFFLE_LENGTH_LONG
+                                     position:WAFFLE_BOTTOM
+                                        image:WAFFLE_RED_X];
+                        return;
                     }
 
                     // resize the splash screen to fit the bound of the window
@@ -274,12 +284,22 @@
                 }
                 case kBTN_TUTORIALS:
                 {
-                    NSLog(@"TUTORIALS!");
+                    // transition to the tutorial storyboard
+                    UIStoryboard *tutorialStoryboard = [UIStoryboard storyboardWithName:@"Tutorial" bundle:nil];
+                    ISMTutorialViewController *tutorialController = [tutorialStoryboard instantiateViewControllerWithIdentifier:@"TutorialStartController"];
+                    [tutorialController setDelegate:self];
+                    [self.parentViewController presentViewController:tutorialController animated:YES completion:nil];
+
                     return;
                 }
                 case kBTN_PRESETS:
                 {
-                    NSLog(@"PRESETS!");
+                    UIStoryboard *presetStoryboard = [UIStoryboard storyboardWithName:@"Preset" bundle:nil];
+                    ISMPresets *presetController = [presetStoryboard
+                        instantiateViewControllerWithIdentifier:@"PresetStartController"];
+                    [presetController setDelegate:self];
+                    [self.parentViewController presentViewController:presetController animated:YES completion:nil];
+
                     return;
                 }
                 default:
@@ -324,9 +344,7 @@
 
     } else /* presetID == kPRESET_DEFAULT */ {
 
-        projID = dev ? kDEFAULT_PROJ_DEV : kDEFAULT_PROJ_PRODUCTION;
-        sampleRate = kS_RATE_FIFTY_MS;
-        recordingLength = kREC_LENGTH_PUSH_TO_STOP;
+        return;
     }
 
     [self setupAppWithProject:projID sampleRate:sampleRate andRecordingLength:recordingLength];
@@ -820,7 +838,7 @@
                                            message:nil
                                           delegate:self
                                  cancelButtonTitle:@"Cancel"
-                                 otherButtonTitles:@"Splash", @"Tutorials", @"Presets", nil];
+                                 otherButtonTitles:@"Credits", @"Tutorials", @"Presets", nil];
     alertView.tag = kMENU_DIALOG_TAG;
     [alertView show];
 

--- a/Apps/Motion/Motion/ISMViewController.m
+++ b/Apps/Motion/Motion/ISMViewController.m
@@ -24,7 +24,8 @@
 // Queue Saver Properties
 @synthesize dataSaver, managedObjectContext;
 // UI
-@synthesize credentialBarBtn, xLbl, yLbl, zLbl, sampleRateBtn, recordingLengthBtn, startStopBtn, nameBtn, uploadBtn, projectBtn;
+@synthesize menuBarBtn, credentialBarBtn, xLbl, yLbl, zLbl, sampleRateBtn;
+@synthesize recordingLengthBtn, startStopBtn, nameBtn, uploadBtn, projectBtn;
 
 
 #pragma mark - View and overriden methods
@@ -243,6 +244,47 @@
             }
             
             break;
+        }
+        case kMENU_DIALOG_TAG:
+        {
+            switch (buttonIndex) {
+                case kBTN_SPLASH:
+                {
+                    // get the splash view from the LaunchScreen xib
+                    NSArray *bundle = [[NSBundle mainBundle] loadNibNamed:@"LaunchScreen" owner:self options:nil];
+                    for (id obj in bundle) {
+                        if ([obj isKindOfClass:[UIView class]]) {
+                            splashView = (UIView *) obj;
+                            break;
+                        }
+                    }
+
+                    // resize the splash screen to fit the bound of the window
+                    splashView.frame = CGRectMake(0, 0, self.view.frame.size.width, self.view.frame.size.height);
+
+                    // replace the current left menu button with a back button
+                    self.navigationItem.leftBarButtonItem.title = @"Back";
+                    self.navigationItem.rightBarButtonItem.enabled = false;
+
+                    // display the splash screen
+                    [self.view addSubview:splashView];
+                    isSplashDisplaying = true;
+
+                    return;
+                }
+                case kBTN_TUTORIALS:
+                {
+                    NSLog(@"TUTORIALS!");
+                    return;
+                }
+                case kBTN_PRESETS:
+                {
+                    NSLog(@"PRESETS!");
+                    return;
+                }
+                default:
+                    return;
+            }
         }
         default:
             break;
@@ -755,6 +797,36 @@
 }
 
 #pragma end - Name
+
+#pragma mark - Menu
+
+- (IBAction)menuBarBtnOnClick:(id)sender {
+
+    if (isSplashDisplaying) {
+
+        // bring back the left menu item
+        self.navigationItem.leftBarButtonItem.title = @"Review";
+        self.navigationItem.rightBarButtonItem.enabled = true;
+
+        // remove the splash screen
+        [splashView removeFromSuperview];
+        isSplashDisplaying = false;
+
+        return;
+    }
+
+    // display user review menu options
+    UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:@"Which screen would you like to review?"
+                                           message:nil
+                                          delegate:self
+                                 cancelButtonTitle:@"Cancel"
+                                 otherButtonTitles:@"Splash", @"Tutorials", @"Presets", nil];
+    alertView.tag = kMENU_DIALOG_TAG;
+    [alertView show];
+
+}
+
+#pragma end - Menu
 
 #pragma mark - Credentials
 

--- a/Apps/Motion/Motion/LaunchScreen.xib
+++ b/Apps/Motion/Motion/LaunchScreen.xib
@@ -13,57 +13,57 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Motion" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cmi-wl-KlH">
-                    <rect key="frame" x="8" y="120" width="464" height="29"/>
+                    <rect key="frame" x="8" y="78" width="464" height="29"/>
                     <fontDescription key="fontDescription" type="system" pointSize="24"/>
                     <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="white_rsense_logo.png" translatesAutoresizingMaskIntoConstraints="NO" id="tK5-T1-ziq">
-                    <rect key="frame" x="110" y="50" width="260" height="62"/>
+                    <rect key="frame" x="110" y="8" width="260" height="62"/>
                     <constraints>
-                        <constraint firstAttribute="width" constant="260" id="SQG-kW-j3L"/>
-                        <constraint firstAttribute="width" secondItem="tK5-T1-ziq" secondAttribute="height" multiplier="130:31" id="g7o-52-WeS"/>
+                        <constraint firstAttribute="width" secondItem="tK5-T1-ziq" secondAttribute="height" multiplier="130:31" id="q7E-sl-Iln"/>
+                        <constraint firstAttribute="height" constant="62" id="xm4-R5-VCj"/>
                     </constraints>
                 </imageView>
                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="machine_science.png" translatesAutoresizingMaskIntoConstraints="NO" id="cdx-SH-3le">
                     <rect key="frame" x="114" y="433" width="253" height="39"/>
                     <constraints>
-                        <constraint firstAttribute="width" constant="253" id="6I5-ys-GvD"/>
-                        <constraint firstAttribute="width" secondItem="cdx-SH-3le" secondAttribute="height" multiplier="253:39" id="zp9-bz-F2G"/>
-                    </constraints>
-                </imageView>
-                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="uml.png" translatesAutoresizingMaskIntoConstraints="NO" id="xXq-zU-MPT">
-                    <rect key="frame" x="168" y="238" width="145" height="165"/>
-                    <constraints>
-                        <constraint firstAttribute="width" secondItem="xXq-zU-MPT" secondAttribute="height" multiplier="29:33" id="fPX-7u-WZI"/>
-                        <constraint firstAttribute="width" constant="145" id="q1d-tu-jCE"/>
+                        <constraint firstAttribute="height" constant="39" id="FrK-EN-ORb"/>
+                        <constraint firstAttribute="width" secondItem="cdx-SH-3le" secondAttribute="height" multiplier="253:39" id="Nxt-D9-LJi"/>
                     </constraints>
                 </imageView>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="isenseproject.org" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rao-ao-MLj">
-                    <rect key="frame" x="8" y="166" width="464" height="29"/>
+                    <rect key="frame" x="8" y="115" width="464" height="29"/>
                     <fontDescription key="fontDescription" type="system" pointSize="24"/>
                     <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     <nil key="highlightedColor"/>
                 </label>
+                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="uml.png" translatesAutoresizingMaskIntoConstraints="NO" id="xXq-zU-MPT">
+                    <rect key="frame" x="188" y="301" width="104" height="124"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="124" id="WyL-ZG-Utp"/>
+                        <constraint firstAttribute="width" secondItem="xXq-zU-MPT" secondAttribute="height" multiplier="26:31" id="kcb-Dc-bjK"/>
+                    </constraints>
+                </imageView>
             </subviews>
             <color key="backgroundColor" red="0.56408546350585731" green="0.22754734914444102" blue="0.76556581439393945" alpha="1" colorSpace="calibratedRGB"/>
             <constraints>
-                <constraint firstItem="rao-ao-MLj" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="8" id="0fI-yk-Zbc"/>
-                <constraint firstAttribute="centerX" secondItem="cdx-SH-3le" secondAttribute="centerX" id="D5g-wc-UzY"/>
-                <constraint firstAttribute="trailing" secondItem="rao-ao-MLj" secondAttribute="trailing" constant="8" id="EKc-d9-NSH"/>
-                <constraint firstAttribute="bottom" secondItem="cdx-SH-3le" secondAttribute="bottom" constant="8" id="TGa-Dp-rq9"/>
-                <constraint firstAttribute="centerX" secondItem="xXq-zU-MPT" secondAttribute="centerX" id="VfO-5B-tfS"/>
-                <constraint firstItem="Cmi-wl-KlH" firstAttribute="top" secondItem="tK5-T1-ziq" secondAttribute="bottom" constant="8" id="XZY-pj-CLm"/>
-                <constraint firstItem="Cmi-wl-KlH" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="8" id="Ynu-q3-vbG"/>
-                <constraint firstItem="rao-ao-MLj" firstAttribute="top" secondItem="Cmi-wl-KlH" secondAttribute="bottom" constant="17" id="d4M-ou-RD7"/>
-                <constraint firstAttribute="trailing" secondItem="Cmi-wl-KlH" secondAttribute="trailing" constant="8" id="ep6-Sk-o82"/>
-                <constraint firstItem="tK5-T1-ziq" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="50" id="oSI-5X-ieQ"/>
-                <constraint firstAttribute="centerX" secondItem="tK5-T1-ziq" secondAttribute="centerX" id="uf4-SQ-NUR"/>
-                <constraint firstItem="cdx-SH-3le" firstAttribute="top" secondItem="xXq-zU-MPT" secondAttribute="bottom" constant="30" id="wcy-aE-O3l"/>
+                <constraint firstItem="Cmi-wl-KlH" firstAttribute="top" secondItem="tK5-T1-ziq" secondAttribute="bottom" constant="8" id="0xO-a9-cYW"/>
+                <constraint firstAttribute="trailing" secondItem="Cmi-wl-KlH" secondAttribute="trailing" constant="8" id="2lj-mi-oTG"/>
+                <constraint firstAttribute="centerX" secondItem="xXq-zU-MPT" secondAttribute="centerX" id="G4E-D8-6dS"/>
+                <constraint firstAttribute="bottom" secondItem="cdx-SH-3le" secondAttribute="bottom" constant="8" id="MBz-sN-PJS"/>
+                <constraint firstItem="rao-ao-MLj" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="8" id="U7m-Ya-viQ"/>
+                <constraint firstItem="Cmi-wl-KlH" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="8" id="aYP-Ce-qNI"/>
+                <constraint firstAttribute="centerX" secondItem="tK5-T1-ziq" secondAttribute="centerX" id="bAq-Jx-d3m"/>
+                <constraint firstItem="rao-ao-MLj" firstAttribute="top" secondItem="Cmi-wl-KlH" secondAttribute="bottom" constant="8" id="cS2-sj-2ul"/>
+                <constraint firstAttribute="centerX" secondItem="cdx-SH-3le" secondAttribute="centerX" id="f0m-Oq-hNq"/>
+                <constraint firstItem="tK5-T1-ziq" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="8" id="h6N-T2-8v3"/>
+                <constraint firstAttribute="trailing" secondItem="rao-ao-MLj" secondAttribute="trailing" constant="8" id="hDB-yT-i4c"/>
+                <constraint firstItem="cdx-SH-3le" firstAttribute="top" secondItem="xXq-zU-MPT" secondAttribute="bottom" constant="8" id="mCD-ED-C7a"/>
             </constraints>
             <nil key="simulatedStatusBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <point key="canvasLocation" x="638" y="694"/>
+            <point key="canvasLocation" x="723" y="795"/>
         </view>
     </objects>
     <resources>

--- a/Apps/Writer/Writer/Base.lproj/LaunchScreen.xib
+++ b/Apps/Writer/Writer/Base.lproj/LaunchScreen.xib
@@ -13,13 +13,13 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Writer" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CxY-0F-EQp">
-                    <rect key="frame" x="8" y="105" width="464" height="29"/>
+                    <rect key="frame" x="8" y="77" width="464" height="29"/>
                     <fontDescription key="fontDescription" type="system" pointSize="24"/>
                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="isenseproject.org" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TPa-w0-6mg">
-                    <rect key="frame" x="8" y="152" width="464" height="29"/>
+                    <rect key="frame" x="8" y="109" width="464" height="29"/>
                     <fontDescription key="fontDescription" type="system" pointSize="24"/>
                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                     <nil key="highlightedColor"/>
@@ -27,40 +27,40 @@
                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="machine_science.png" translatesAutoresizingMaskIntoConstraints="NO" id="p7N-GG-Sd4">
                     <rect key="frame" x="114" y="433" width="253" height="39"/>
                     <constraints>
-                        <constraint firstAttribute="width" constant="253" id="cel-if-82G"/>
-                        <constraint firstAttribute="width" secondItem="p7N-GG-Sd4" secondAttribute="height" multiplier="253:39" id="dAd-yc-gO8"/>
+                        <constraint firstAttribute="height" constant="39" id="eNg-B9-ecq"/>
+                        <constraint firstAttribute="width" secondItem="p7N-GG-Sd4" secondAttribute="height" multiplier="253:39" id="x5T-eU-vkQ"/>
                     </constraints>
                 </imageView>
                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="white_rsense_logo.png" translatesAutoresizingMaskIntoConstraints="NO" id="oyp-06-rW8">
-                    <rect key="frame" x="112" y="36" width="257" height="61"/>
+                    <rect key="frame" x="112" y="8" width="257" height="61"/>
                     <constraints>
-                        <constraint firstAttribute="width" constant="257" id="S85-7R-PIg"/>
-                        <constraint firstAttribute="width" secondItem="oyp-06-rW8" secondAttribute="height" multiplier="257:61" id="dk6-dZ-oER"/>
+                        <constraint firstAttribute="width" secondItem="oyp-06-rW8" secondAttribute="height" multiplier="257:61" id="hv8-xz-0ac"/>
+                        <constraint firstAttribute="height" constant="61" id="ips-fz-1BR"/>
                     </constraints>
                 </imageView>
                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="uml.png" translatesAutoresizingMaskIntoConstraints="NO" id="dCH-Pv-91J">
-                    <rect key="frame" x="168" y="243" width="145" height="165"/>
+                    <rect key="frame" x="184" y="296" width="113" height="129"/>
                     <constraints>
-                        <constraint firstAttribute="width" constant="145" id="hMB-59-2XU"/>
-                        <constraint firstAttribute="width" secondItem="dCH-Pv-91J" secondAttribute="height" multiplier="29:33" id="rBq-CV-EzA"/>
+                        <constraint firstAttribute="width" constant="113" id="Pti-cA-VBI"/>
+                        <constraint firstAttribute="width" secondItem="dCH-Pv-91J" secondAttribute="height" multiplier="113:129" id="eLl-Is-ekC"/>
                     </constraints>
                 </imageView>
             </subviews>
             <color key="backgroundColor" red="0.55051685292275998" green="0.91708096590909094" blue="0.50638223403994675" alpha="1" colorSpace="calibratedRGB"/>
             <constraints>
-                <constraint firstItem="CxY-0F-EQp" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="8" id="J6L-Zr-qdF"/>
-                <constraint firstItem="p7N-GG-Sd4" firstAttribute="top" secondItem="dCH-Pv-91J" secondAttribute="bottom" constant="25" id="PEq-mB-zMF"/>
-                <constraint firstAttribute="centerX" secondItem="oyp-06-rW8" secondAttribute="centerX" id="WC1-Vg-H5M"/>
-                <constraint firstAttribute="centerX" secondItem="dCH-Pv-91J" secondAttribute="centerX" id="XA3-rs-dyo"/>
-                <constraint firstItem="oyp-06-rW8" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="36" id="bZV-Ui-vud"/>
-                <constraint firstAttribute="trailing" secondItem="TPa-w0-6mg" secondAttribute="trailing" constant="8" id="hD5-ew-qUV"/>
-                <constraint firstAttribute="trailing" secondItem="CxY-0F-EQp" secondAttribute="trailing" constant="8" id="la5-h5-ogW"/>
-                <constraint firstAttribute="bottom" secondItem="p7N-GG-Sd4" secondAttribute="bottom" constant="8" id="nrt-MJ-k7L"/>
+                <constraint firstAttribute="trailing" secondItem="TPa-w0-6mg" secondAttribute="trailing" constant="8" id="3VC-bw-KPW"/>
+                <constraint firstAttribute="centerX" secondItem="p7N-GG-Sd4" secondAttribute="centerX" id="B52-m5-hHb"/>
+                <constraint firstItem="p7N-GG-Sd4" firstAttribute="top" secondItem="dCH-Pv-91J" secondAttribute="bottom" constant="8" id="Jcw-wi-s6H"/>
+                <constraint firstItem="TPa-w0-6mg" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="8" id="Rmm-SF-Dcw"/>
+                <constraint firstAttribute="trailing" secondItem="CxY-0F-EQp" secondAttribute="trailing" constant="8" id="U0T-MP-RqO"/>
+                <constraint firstItem="TPa-w0-6mg" firstAttribute="top" secondItem="CxY-0F-EQp" secondAttribute="bottom" constant="3" id="cfw-jg-GqW"/>
+                <constraint firstItem="oyp-06-rW8" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="8" id="dru-es-lFW"/>
+                <constraint firstItem="CxY-0F-EQp" firstAttribute="top" secondItem="oyp-06-rW8" secondAttribute="bottom" constant="8" id="gVn-nA-D2L"/>
+                <constraint firstAttribute="bottom" secondItem="p7N-GG-Sd4" secondAttribute="bottom" constant="8" id="lvO-Ib-7Aj"/>
                 <constraint firstAttribute="centerX" secondItem="CxY-0F-EQp" secondAttribute="centerX" id="pEl-J9-cbb"/>
-                <constraint firstItem="CxY-0F-EQp" firstAttribute="top" secondItem="oyp-06-rW8" secondAttribute="bottom" constant="8" id="uhT-rb-3qh"/>
-                <constraint firstItem="TPa-w0-6mg" firstAttribute="top" secondItem="CxY-0F-EQp" secondAttribute="bottom" constant="18" id="v7x-O0-ZW4"/>
-                <constraint firstAttribute="centerX" secondItem="p7N-GG-Sd4" secondAttribute="centerX" id="vkT-ce-SrN"/>
-                <constraint firstItem="TPa-w0-6mg" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="8" id="zcF-FD-Aak"/>
+                <constraint firstItem="CxY-0F-EQp" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="8" id="qWu-h1-OSw"/>
+                <constraint firstAttribute="centerX" secondItem="oyp-06-rW8" secondAttribute="centerX" id="ynL-kd-tGm"/>
+                <constraint firstAttribute="centerX" secondItem="dCH-Pv-91J" secondAttribute="centerX" id="z8x-EF-Clu"/>
             </constraints>
             <nil key="simulatedStatusBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
@@ -69,7 +69,7 @@
                     <exclude reference="pEl-J9-cbb"/>
                 </mask>
             </variation>
-            <point key="canvasLocation" x="276" y="494"/>
+            <point key="canvasLocation" x="233" y="362"/>
         </view>
     </objects>
     <resources>

--- a/Apps/Writer/Writer/Base.lproj/Main.storyboard
+++ b/Apps/Writer/Writer/Base.lproj/Main.storyboard
@@ -115,6 +115,11 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="iS Writer" id="kmv-hw-1QN">
+                        <barButtonItem key="leftBarButtonItem" title="Review" id="FcC-ri-760">
+                            <connections>
+                                <action selector="menuBarBtnOnClick:" destination="BYZ-38-t0r" id="F78-hC-G6A"/>
+                            </connections>
+                        </barButtonItem>
                         <barButtonItem key="rightBarButtonItem" title="Account" id="PDD-qH-Xe2">
                             <connections>
                                 <action selector="credentialBarBtnOnClick:" destination="BYZ-38-t0r" id="PJk-2g-qsm"/>
@@ -126,6 +131,7 @@
                         <outlet property="credentialBarBtn" destination="PDD-qH-Xe2" id="3zz-BS-9Wq"/>
                         <outlet property="dataSetNameLbl" destination="Y7S-FE-Ls6" id="TdC-tJ-cVF"/>
                         <outlet property="dataSetNameTxt" destination="54V-NH-Tzx" id="Vza-Yp-RsC"/>
+                        <outlet property="menuBarBtn" destination="FcC-ri-760" id="IwE-98-uf9"/>
                         <outlet property="projectBtn" destination="bQf-e3-Lo2" id="bTw-pW-TSV"/>
                         <outlet property="saveDataSetBtn" destination="lhp-lV-Nqi" id="plM-Uq-9OD"/>
                         <outlet property="saveRowBtn" destination="rCY-xT-VVx" id="NdN-ny-ffO"/>

--- a/Apps/Writer/Writer/Constants.h
+++ b/Apps/Writer/Writer/Constants.h
@@ -11,10 +11,17 @@
 
 // dialog constants
 #define kLOGIN_DIALOG_TAG 100
+
 #define kVISUALIZE_DIALOG_TAG 200
+
 #define kLOCATION_DIALOG_IOS_8_AND_LATER_TAG 301
 #define kLOCATION_DIALOG_IOS_7_AND_EARLIER_TAG 302
+
 #define kUPLOAD_CONFIRMATION_DIALOG_TAG 400
+
+#define kMENU_DIALOG_TAG 500
+#define kBTN_SPLASH 1
+#define kBTN_TUTORIALS 2
 
 // project constants
 #define kNO_PROJECT @"Not Set"

--- a/Apps/Writer/Writer/ISWViewController.h
+++ b/Apps/Writer/Writer/ISWViewController.h
@@ -66,6 +66,10 @@
 
     // Footer view for the table view
     UILabel *tableFooter;
+
+    // UIView to display the splash screen and a boolean to track if it is displaying
+    UIView *splashView;
+    bool isSplashDisplaying;
 }
 
 // Queue Saver properties
@@ -75,6 +79,9 @@
 // UI properties
 @property (weak, nonatomic) IBOutlet UIBarButtonItem *credentialBarBtn;
 - (IBAction)credentialBarBtnOnClick:(id)sender;
+
+@property (weak, nonatomic) IBOutlet UIBarButtonItem *menuBarBtn;
+- (IBAction)menuBarBtnOnClick:(id)sender;
 
 @property (weak, nonatomic) IBOutlet UILabel *dataSetNameLbl;
 @property (weak, nonatomic) IBOutlet UITextField *dataSetNameTxt;

--- a/Apps/Writer/Writer/ISWViewController.m
+++ b/Apps/Writer/Writer/ISWViewController.m
@@ -26,7 +26,7 @@
 // Queue Saver Properties
 @synthesize dataSaver, managedObjectContext;
 // UI
-@synthesize credentialBarBtn, dataSetNameLbl, dataSetNameTxt, projectBtn, saveRowBtn, saveDataSetBtn, contentView, uploadBtn;
+@synthesize credentialBarBtn, menuBarBtn, dataSetNameLbl, dataSetNameTxt, projectBtn, saveRowBtn, saveDataSetBtn, contentView, uploadBtn;
 
 
 #pragma mark - View and UI code
@@ -352,6 +352,36 @@
 }
 
 #pragma end - View and UI code
+
+#pragma mark - Menu
+
+- (IBAction)menuBarBtnOnClick:(id)sender {
+
+    if (isSplashDisplaying) {
+
+        // bring back the left menu item
+        self.navigationItem.leftBarButtonItem.title = @"Review";
+        self.navigationItem.rightBarButtonItem.enabled = true;
+
+        // remove the splash screen
+        [splashView removeFromSuperview];
+        isSplashDisplaying = false;
+
+        return;
+    }
+
+    // display user review menu options
+    UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:@"Which screen would you like to review?"
+                                                        message:nil
+                                                       delegate:self
+                                              cancelButtonTitle:@"Cancel"
+                                              otherButtonTitles:@"Credits", @"Tutorials", nil];
+    alertView.tag = kMENU_DIALOG_TAG;
+    [alertView show];
+    
+}
+
+#pragma end - Menu
 
 #pragma mark - TableView code
 
@@ -891,6 +921,56 @@
         {
             if (buttonIndex != OPTION_CANCELED) {
                 [self launchDataSaverView];
+            }
+        }
+        case kMENU_DIALOG_TAG:
+        {
+            switch (buttonIndex) {
+                case kBTN_SPLASH:
+                {
+                    if (!splashView) {
+                        // get the splash view from the LaunchScreen xib
+                        NSArray *bundle = [[NSBundle mainBundle] loadNibNamed:@"LaunchScreen" owner:self options:nil];
+                        for (id obj in bundle) {
+                            if ([obj isKindOfClass:[UIView class]]) {
+                                splashView = (UIView *) obj;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (!splashView) {
+                        [self.view makeWaffle:@"Error loading splash screen"
+                                     duration:WAFFLE_LENGTH_LONG
+                                     position:WAFFLE_BOTTOM
+                                        image:WAFFLE_RED_X];
+                        return;
+                    }
+
+                    // resize the splash screen to fit the bound of the window
+                    splashView.frame = CGRectMake(0, 0, self.view.frame.size.width, self.view.frame.size.height);
+
+                    // replace the current left menu button with a back button
+                    self.navigationItem.leftBarButtonItem.title = @"Back";
+                    self.navigationItem.rightBarButtonItem.enabled = false;
+
+                    // display the splash screen
+                    [self.view addSubview:splashView];
+                    isSplashDisplaying = true;
+
+                    return;
+                }
+                case kBTN_TUTORIALS:
+                {
+                    // transition to the tutorial storyboard
+                    UIStoryboard *tutorialStoryboard = [UIStoryboard storyboardWithName:@"Tutorial" bundle:nil];
+                    ISWTutorialViewController *tutorialController = [tutorialStoryboard instantiateViewControllerWithIdentifier:@"TutorialStartController"];
+                    [self.parentViewController presentViewController:tutorialController animated:YES completion:nil];
+
+                    return;
+                }
+                default:
+                    return;
             }
         }
         default:

--- a/Apps/Writer/Writer/ISWViewController.m
+++ b/Apps/Writer/Writer/ISWViewController.m
@@ -922,6 +922,7 @@
             if (buttonIndex != OPTION_CANCELED) {
                 [self launchDataSaverView];
             }
+            break;
         }
         case kMENU_DIALOG_TAG:
         {


### PR DESCRIPTION
Addresses #81 

The request here was to add the ability for the user to re-display the splash screen, tutorials, and presets via the menu.  I have implemented all 3 in a single left-menu item called "Review."
